### PR TITLE
Change to annualized sharpe ratio calculation

### DIFF
--- a/pybacktest/performance.py
+++ b/pybacktest/performance.py
@@ -31,7 +31,7 @@ _days = lambda eqd: eqd.resample('D', how='sum').dropna()
 def sharpe(eqd):
     ''' daily sharpe ratio '''
     d = _days(eqd)
-    return (d.mean() / d.std()) ** (252**0.5)
+    return (d.mean() / d.std()) * (252**0.5)
 
 
 def sortino(eqd):


### PR DESCRIPTION
Changes sharpe() function from `(d.mean()/d.std())**(252**.5)` to `(d.mean()/d.std())*(252**.5)`.

Addresses issue #14 (sharpe ratio calc).