### PR TITLE
Modified the plotting functions to accept matplotlib axes.

### DIFF
--- a/pybacktest/backtest.py
+++ b/pybacktest/backtest.py
@@ -176,6 +176,7 @@ class Backtest(object):
 
     def plot_equity(self, subset=None, ax=None):
         import matplotlib.pylab as pylab
+        _ = None
         if ax is None:
             _,ax = pylab.subplots()
         
@@ -197,6 +198,7 @@ class Backtest(object):
         ax.legend(loc='best')
         ax.set_title(str(self))
         ax.set_ylabel('Equity for %s' % subset)
+        return _,ax
 
     def plot_trades(self, subset=None, ax=None):
         if subset is None:
@@ -208,6 +210,7 @@ class Backtest(object):
         sx = fr.price[(fr.pos.shift() < 0) & (fr.vol > 0)]
 
         import matplotlib.pylab as pylab
+        _ = None
         if ax is None:
             _,ax = pylab.subplots()
 
@@ -221,4 +224,5 @@ class Backtest(object):
                    label='short exit')
         
         self.ohlc.O.ix[subset].plot(color='black', label='price', ax=ax)
-        ax.set_ylabel('Trades for %s' % subset)
+        ax.set_ylabel('Trades for %s' % subset)i
+        return _,ax


### PR DESCRIPTION
This was a really useful change for me.  Examples:

```python
fig, ax = plt.subplots()
bt.plot_trades(ax=ax)

analysis = pd.DataFrame(...) # something else to plot
ax.plot(analysis)

eq_ax = ax.twinx()
bt.plot_equity(ax=eq_ax)
```

By default, `plot_equity` and `plot_trades` functions will create new `(fig, ax)` pairs and return them for further manipulation:

```python
fig, ax = bt.plot_trades()
ax.set_ylabel('what goes up must come down')

analysis = pd.DataFrame(...) # something else to plot
ax.plot(analysis)

eq_ax = ax.twinx()
bt.plot_equity(ax=eq_ax)
```

I've been using `%matplotlib notebook`, which means I don't really have much use for the subset system, but by default, titles are based on that.  Maybe you have a good idea on how to make them more generic by default?