### PR TITLE
Upgrade pandas for deprecated .ix()

### DIFF
--- a/pybacktest/backtest.py
+++ b/pybacktest/backtest.py
@@ -190,7 +190,7 @@ class Backtest(object):
         eq.plot(color='red', style='-',ax=ax)
 
         #eq.plot(color='red', label='strategy',ax=ax)
-        #ix = self.ohlc.ix[eq.index[0]:eq.index[-1]].index
+        #ix = self.ohlc.loc[eq.index[0]:eq.index[-1]].index
         #price = self.ohlc.C
         #(price[ix] - price[ix][0]).resample('W').first().dropna() \
         #    .plot(color='black', alpha=0.5, label='underlying', ax=ax)
@@ -203,7 +203,7 @@ class Backtest(object):
     def plot_trades(self, subset=None, ax=None):
         if subset is None:
             subset = slice(None, None)
-        fr = self.trades.ix[subset]
+        fr = self.trades.loc[subset]
         le = fr.price[(fr.pos > 0) & (fr.vol > 0)]
         se = fr.price[(fr.pos < 0) & (fr.vol < 0)]
         lx = fr.price[(fr.pos.shift() > 0) & (fr.vol < 0)]
@@ -223,6 +223,6 @@ class Backtest(object):
         ax.plot(sx.index, sx.values, 'o', color='red', markersize=7,
                    label='short exit')
         
-        self.ohlc.O.ix[subset].plot(color='black', label='price', ax=ax)
+        self.ohlc.O.loc[subset].plot(color='black', label='price', ax=ax)
         ax.set_ylabel('Trades for %s' % subset)
         return _,ax

--- a/pybacktest/backtest.py
+++ b/pybacktest/backtest.py
@@ -185,7 +185,7 @@ class Backtest(object):
         assert isinstance(subset, slice)
         eq = self.equity[subset].cumsum()
         
-        eq = self.equity.ix[subset].cumsum()
+        eq = self.equity.loc[subset].cumsum()
         ix = eq.index
         eq.plot(color='red', style='-',ax=ax)
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # coding: utf8
 
-VERSION = '0.1.1'
+VERSION = '0.1.2'
 
 import sys
 
@@ -18,7 +18,8 @@ setup(name='pybacktest',
       url='https://github.com/ematvey/pybacktest',
       packages=['pybacktest'],
       install_requires=['numpy>=1.11',
-                        'pandas>=0.19',
+                        'pandas>=0.20',
+                        'pandas-datareader',
                         'pyyaml',
                         'cached_property'],
       **extra_args)


### PR DESCRIPTION
Replace .ix() with .loc().
Use Pandas 0.20 or above for deprecated .ix().
Add 'pandas-datareader' in setup.