### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pybacktest/ami_funcs.py
+++ b/pybacktest/ami_funcs.py
@@ -1,9 +1,9 @@
 # part of pybacktest package: https://github.com/ematvey/pybacktest
 
-""" Set of pandas.Series processing functions, mimicing AmiBroker's built-ins
+""" Set of pandas.Series processing functions, mimicking AmiBroker's built-ins
 to help translate strategies from AmiScript.
 
-Note that most AmiScript's built-in funtions have more advanced native analogs
+Note that most AmiScript's built-in functions have more advanced native analogs
 in pandas. Funcs like that will not be replicated here.
 
 """
@@ -35,7 +35,7 @@ def ExRem(array1, array2):
 
 
 def BarsSince(x):
-    """ Counts number of periods since last True occured.
+    """ Counts number of periods since last True occurred.
 
     Reference implementation:
     http://www.amibroker.com/guide/afl/afl_view.php?name=barssince

--- a/pybacktest/backtest.py
+++ b/pybacktest/backtest.py
@@ -75,7 +75,7 @@ class Backtest(object):
 
         *price_fields* specifies names of price Series where trades will take
         place. If some price is not specified (NaN at signal's timestamp, or
-        corresponding Series not present in dataobj altogather), defaults to
+        corresponding Series not present in dataobj altogether), defaults to
         Open price of next bar. By default follows AmiBroker's naming
         convention.
 


### PR DESCRIPTION
There are small typos in:
- pybacktest/ami_funcs.py
- pybacktest/backtest.py

Fixes:
- Should read `occurred` rather than `occured`.
- Should read `mimicking` rather than `mimicing`.
- Should read `functions` rather than `funtions`.
- Should read `altogether` rather than `altogather`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md