### PR TITLE
Fixed the use_2to3 for setuptools >= 58

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,13 @@ VERSION = '0.1.1'
 
 import sys
 
+import setuptools
 from setuptools import setup
 
+setuptools_major_version = int(setuptools.__version__.split('.')[0])
+
 extra_args = {}
-if (sys.version_info[0] >= 3):
+if (sys.version_info[0] >= 3) and setuptools_major_version < 58:
     extra_args['use_2to3'] = True
 
 setup(name='pybacktest',


### PR DESCRIPTION
Fixed the `use_2to3` usage for setuptools >= 58